### PR TITLE
Move "What's New" up to the top for visibility

### DIFF
--- a/src/_data/navigation.yml
+++ b/src/_data/navigation.yml
@@ -3,7 +3,9 @@ toc:
     folderitems:
     - page: Introduction
       url: /software/introduction/
-    subfolders: 
+    - page: What's New
+      url: /resources/new/
+    subfolders:
       - title: Guides
         subfolderitems:
           - page: Getting Started
@@ -80,5 +82,3 @@ toc:
       - page: Dev Channel
         url: https://www.geotab.com/dev-channel/
         external: true
-      - page: What's New
-        url: /resources/new/


### PR DESCRIPTION
Problem:
When viewing the SDK, it is difficult for people to find out "What's New" in recent releases.

Proposed solution:
Move "What's New" up to the top underneath "Introduction". Not 100% sure with this yml format, but it looks like these changes should be right.

![image](https://user-images.githubusercontent.com/1085938/56675055-3824cf80-6689-11e9-9162-37ea1589bd06.png)

