### PR TITLE
option disable selected value

### DIFF
--- a/src/software/js-samples/importUsers.html
+++ b/src/software/js-samples/importUsers.html
@@ -266,7 +266,7 @@
 						<div class="checkmateField">
 							<label for="options_hosRuleSet">Ruleset:</label>
 							<select id="options_hosRuleSet" class="checkmateFormEditField" title="This is the ruleset the user will follow when using hours of service.">
-								<option disabled selected value> -- select an ruleset -- </option>
+								<option disabled selected value> -- select a ruleset -- </option>
 								<option value="HosRuleSetAlaskaPassenger7Day">Alaska Passenger 70-hour/7-day</option>
 								<option value="HosRuleSetAlaskaPassenger8Day">Alaska Passenger 80-hour/8-day</option>
 								<option value="HosRuleSetAlaskaProperty7Day">Alaska Property 70-hour/7-day</option>

--- a/src/software/js-samples/importUsers.html
+++ b/src/software/js-samples/importUsers.html
@@ -266,7 +266,7 @@
 						<div class="checkmateField">
 							<label for="options_hosRuleSet">Ruleset:</label>
 							<select id="options_hosRuleSet" class="checkmateFormEditField" title="This is the ruleset the user will follow when using hours of service.">
-								<option value=null></option>"Please select a ruleset"</option>
+								<option disabled selected value> -- select an ruleset -- </option>
 								<option value="HosRuleSetAlaskaPassenger7Day">Alaska Passenger 70-hour/7-day</option>
 								<option value="HosRuleSetAlaskaPassenger8Day">Alaska Passenger 80-hour/8-day</option>
 								<option value="HosRuleSetAlaskaProperty7Day">Alaska Property 70-hour/7-day</option>


### PR DESCRIPTION
Fixed a bug where if ruleset is left blank it results in a postgres exception. Removed the null value as the default option, and disabled the selected value.