### PR TITLE
Use leaflet maps library instead of mapbox library

### DIFF
--- a/src/software/js-samples/addZone.html
+++ b/src/software/js-samples/addZone.html
@@ -7,7 +7,7 @@
 
         <title>Geotab SDK | Add zone example</title>
 
-        <link href="js/mapbox/mapbox.css" rel="stylesheet" type="text/css" />
+        <link href="js/leaflet/leaflet.css" rel="stylesheet" type="text/css" />
         <link href="css/geotab.css" rel="stylesheet" type="text/css" />
 
     </head>
@@ -98,7 +98,7 @@
             </p>
         </div>
 
-        <script src="js/mapbox/mapbox.js"></script>
+        <script src="js/leaflet/leaflet.js"></script>
         <script src="js/api.js"></script>
         <script src="js/login.js"></script>
 
@@ -109,10 +109,12 @@
             var zonePoints;
 
             document.addEventListener("DOMContentLoaded", function () {
-                // Initialize MapBox engine (http://www.mapbox.com)
-                L.mapbox.accessToken = "pk.eyJ1IjoiZ2VvdGFiIiwiYSI6ImNpd2Nlam5tajA2cHIyenBmdDQyZG9mMGYifQ.I7NikOui41_ka1TbbFGkFw";
-                map = L.mapbox.map("map").setView([43.437111,-79.712756], 13);
-                L.mapbox.styleLayer("mapbox://styles/mapbox/streets-v10").addTo(map);
+                // Set up Leaflet map (https://leafletjs.com)
+                map = new L.Map("map").setView([43.437111,-79.712756], 13);
+                L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+                    subdomains: ['a','b','c']
+                }).addTo(map);
                 layerGroup = L.layerGroup().addTo(map);
 
                 document.getElementById("example-content-details").style.display = "none";

--- a/src/software/js-samples/getLocation.html
+++ b/src/software/js-samples/getLocation.html
@@ -132,7 +132,7 @@
                     var marker = L.marker(location).bindPopup(
                         "<strong>" + device.name + "</strong><br />" +
                         location.lat + ", " + location.lng);
-                    
+
                     layerGroup.clearLayers().addLayer(marker);
                     map.setView(location, 15);
                 }, function (error) {

--- a/src/software/js-samples/getLocation.html
+++ b/src/software/js-samples/getLocation.html
@@ -7,7 +7,7 @@
 
         <title>Geotab SDK | Get device location example</title>
 
-        <link href="js/mapbox/mapbox.css" rel="stylesheet" type="text/css" />
+        <link href="js/leaflet/leaflet.css" rel="stylesheet" type="text/css" />
         <link href="css/geotab.css" rel="stylesheet" type="text/css" />
 
     </head>
@@ -73,7 +73,7 @@
             </p>
         </div>
 
-        <script src="js/mapbox/mapbox.js"></script>
+        <script src="js/leaflet/leaflet.js"></script>
         <script src="js/api.js"></script>
         <script src="js/login.js"></script>
 
@@ -83,10 +83,12 @@
             var layerGroup;
 
             document.addEventListener("DOMContentLoaded", function () {
-                // Initialize MapBox engine (http://www.mapbox.com)
-                L.mapbox.accessToken = "pk.eyJ1IjoiZ2VvdGFiIiwiYSI6ImNpd2Nlam5tajA2cHIyenBmdDQyZG9mMGYifQ.I7NikOui41_ka1TbbFGkFw";
-                map = L.mapbox.map("map").setView([43.437111,-79.712756], 13);
-                L.mapbox.styleLayer("mapbox://styles/mapbox/streets-v10").addTo(map);
+                // Set up Leaflet map (https://leafletjs.com)
+                map = new L.Map("map").setView([43.437111,-79.712756], 13);
+                L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+                    subdomains: ['a','b','c']
+                }).addTo(map);
                 layerGroup = L.layerGroup().addTo(map);
 
                 document.getElementById("search").addEventListener("click", function (event) {
@@ -116,7 +118,7 @@
                 });
             });
 
-            // Retrieves the current location of a device and displays it on MapBox
+            // Retrieves the current location of a device and displays it on Leaflet
             function showDeviceLocation(device) {
                 api.call("Get", {
                     typeName: "DeviceStatusInfo",
@@ -130,7 +132,7 @@
                     var marker = L.marker(location).bindPopup(
                         "<strong>" + device.name + "</strong><br />" +
                         location.lat + ", " + location.lng);
-
+                    
                     layerGroup.clearLayers().addLayer(marker);
                     map.setView(location, 15);
                 }, function (error) {

--- a/src/software/js-samples/moveZone.html
+++ b/src/software/js-samples/moveZone.html
@@ -7,7 +7,7 @@
 
         <title>Geotab SDK | Move zone example</title>
 
-        <link href="js/mapbox/mapbox.css" rel="stylesheet" type="text/css" />
+        <link href="js/leaflet/leaflet.css" rel="stylesheet" type="text/css" />
         <link href="css/geotab.css" rel="stylesheet" type="text/css" />
 
     </head>
@@ -79,7 +79,7 @@
             </p>
         </div>
 
-        <script src="js/mapbox/mapbox.js"></script>
+        <script src="js/leaflet/leaflet.js"></script>
         <script src="js/api.js"></script>
         <script src="js/login.js"></script>
 
@@ -95,10 +95,12 @@
                 // Download a group of zones to work with
                 populateZones(1000);
 
-                // Initialize MapBox engine (http://www.mapbox.com)
-                L.mapbox.accessToken = "pk.eyJ1IjoiZ2VvdGFiIiwiYSI6ImNpd2Nlam5tajA2cHIyenBmdDQyZG9mMGYifQ.I7NikOui41_ka1TbbFGkFw";
-                map = L.mapbox.map("map").setView([43.437111,-79.712756], 13);
-                L.mapbox.styleLayer("mapbox://styles/mapbox/streets-v10").addTo(map);
+                // Set up Leaflet map (https://leafletjs.com)
+                map = new L.Map("map").setView([43.437111,-79.712756], 13);
+                L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+                    subdomains: ['a','b','c']
+                }).addTo(map);
                 featureGroup = L.featureGroup().addTo(map);
 
                 document.getElementById("zone").addEventListener("change", function(event) {

--- a/src/software/js-samples/showTrips.html
+++ b/src/software/js-samples/showTrips.html
@@ -7,7 +7,7 @@
 
         <title>Geotab SDK | Show device trips</title>
 
-        <link href="js/mapbox/mapbox.css" rel="stylesheet" type="text/css" />
+        <link href="js/leaflet/leaflet.css" rel="stylesheet" type="text/css" />
         <link href="css/geotab.css" rel="stylesheet" type="text/css" />
 
     </head>
@@ -78,7 +78,7 @@
             </p>
         </div>
 
-        <script src="js/mapbox/mapbox.js"></script>
+        <script src="js/leaflet/leaflet.js"></script>
         <script src="js/api.js"></script>
         <script src="js/login.js"></script>
 
@@ -89,10 +89,12 @@
 
             document.addEventListener("DOMContentLoaded", function () {
 
-                // Initialize MapBox engine (http://www.mapbox.com)
-                L.mapbox.accessToken = "pk.eyJ1IjoiZ2VvdGFiIiwiYSI6ImNpd2Nlam5tajA2cHIyenBmdDQyZG9mMGYifQ.I7NikOui41_ka1TbbFGkFw";
-                map = L.mapbox.map("map").setView([43.437111,-79.712756], 13);
-                L.mapbox.styleLayer("mapbox://styles/mapbox/streets-v10").addTo(map);
+                // Set up Leaflet map (https://leafletjs.com)
+                map = new L.Map("map").setView([43.437111,-79.712756], 13);
+                L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>',
+                    subdomains: ['a','b','c']
+                }).addTo(map);
                 featureGroup = L.featureGroup().addTo(map);
 
                 // Download devices to work with


### PR DESCRIPTION
Mapbox required geotab specific access token whereas leaflet does not and utilizes open source open street maps tiles.