### PR TITLE
ESUP 18272 - Changes to updated GetFeed example

### DIFF
--- a/src/software/js-samples/css/JavaScriptExamples.css
+++ b/src/software/js-samples/css/JavaScriptExamples.css
@@ -570,8 +570,19 @@ p {
     padding-top: 1rem;
     color: #575757;
 }
+.feed-container {
+    overflow: hidden;
+    width: 70%; 
+    height: 500px;
+    float: right;
+    margin: 1.5rem 2rem 0rem 0rem;
+}
 
-.map-container, .feed-container, .graph-container {
+.feed-container:hover {
+    overflow: scroll;
+}
+
+.map-container, .graph-container {
     width: 750px;
     float: right;
     margin: 1.5rem 2rem 0rem 0rem;

--- a/src/software/js-samples/css/JavaScriptExamples.css
+++ b/src/software/js-samples/css/JavaScriptExamples.css
@@ -572,7 +572,7 @@ p {
 }
 .feed-container {
     overflow: hidden;
-    width: 70%; 
+    width: 55%; 
     height: 500px;
     float: right;
     margin: 1.5rem 2rem 0rem 0rem;

--- a/src/software/js-samples/dataFeedUpdated.html
+++ b/src/software/js-samples/dataFeedUpdated.html
@@ -128,7 +128,7 @@
             var updateInterval = 5; // In seconds
             var update = null;
             var lastVersions = [ null, null, null ];
-            var startDate = new Date(new Date(new Date().setUTCHours(4,0,0,1)) - 24*60*60*1000).toISOString();
+            var startDate = new Date(new Date(new Date().setUTCHours(0,0,0,1)) - 24*60*60*1000).toISOString();
 
             document.addEventListener("DOMContentLoaded", function() {
 

--- a/src/software/js-samples/dataFeedUpdated.html
+++ b/src/software/js-samples/dataFeedUpdated.html
@@ -65,13 +65,13 @@
                 <div class="api-references">In this example
                     <details open>
                         <summary>API Methods:</summary>
-                        <a href="https://geotab.github.io/sdk/software/api/reference/#GetFeed1" target="_blank">Get Feed</a>
+                        <a href="https://geotab.github.io/sdk/software/api/reference/#GetFeed1" target="_blank">GetFeed</a>
                     </details>      
                     <details open>
                         <summary>API Entities:</summary>
-                        <a href="https://geotab.github.io/sdk/software/api/reference/#FaultData" target="_blank">Fault Data</a>
-                        <a href="https://geotab.github.io/sdk/software/api/reference/#LogRecord" target="_blank">Log Record</a>
-                        <a href="https://geotab.github.io/sdk/software/api/reference/#StatusData" target="_blank">Status Data</a>
+                        <a href="https://geotab.github.io/sdk/software/api/reference/#FaultData" target="_blank">FaultData</a>
+                        <a href="https://geotab.github.io/sdk/software/api/reference/#LogRecord" target="_blank">LogRecord</a>
+                        <a href="https://geotab.github.io/sdk/software/api/reference/#StatusData" target="_blank">StatusData</a>
                     </details>
                 </div>
             </div>

--- a/src/software/js-samples/dataFeedUpdated.html
+++ b/src/software/js-samples/dataFeedUpdated.html
@@ -128,7 +128,7 @@
             var updateInterval = 5; // In seconds
             var update = null;
             var lastVersions = [ null, null, null ];
-            var startDate = new Date(new Date(new Date().setUTCHours(0,0,0,1)) - 24*60*60*1000).toISOString();
+            var startDate = new Date(new Date().setUTCHours(0,0,0,0) - 24*60*60*1000).toISOString();
 
             document.addEventListener("DOMContentLoaded", function() {
 
@@ -147,6 +147,7 @@
                     } else {
                         if (update) {
                             clearInterval(update);
+                            lastVersions = [null, null, null];
                         }
                     }
                 });

--- a/src/software/js-samples/dataFeedUpdated.html
+++ b/src/software/js-samples/dataFeedUpdated.html
@@ -128,7 +128,7 @@
             var updateInterval = 5; // In seconds
             var update = null;
             var lastVersions = [ null, null, null ];
-            var startDate = new Date().toISOString();
+            var startDate = new Date(new Date(new Date().setUTCHours(4,0,0,1)) - 24*60*60*1000).toISOString();
 
             document.addEventListener("DOMContentLoaded", function() {
 
@@ -176,7 +176,8 @@
                         "fromVersion": lastVersions[0],
                         "search": {
                             "fromDate": startDate
-                        }
+                        },
+                        "resultsLimit": 1000,
                     }]);
                 }
 
@@ -186,7 +187,8 @@
                         "fromVersion": lastVersions[1],
                         "search": {
                             "fromDate": startDate
-                        }
+                        },
+                        "resultsLimit": 1000,
                     }]);
                 }
 
@@ -196,7 +198,8 @@
                         "fromVersion": lastVersions[2],
                         "search": {
                             "fromDate": startDate
-                        }
+                        },
+                        "resultsLimit": 1000,
                     }]);
                 }
 


### PR DESCRIPTION
Changes + bug fixes to the GetFeed example table:
- table no longer flows off screen when populated
- table populates with data points instead of being empty 
- table is now scrollable when there is enough data
- updated entity name Links such as Get Feed or Fault Data to match the SDK reference page
