### PR TITLE
Removed entity name feature in console

### DIFF
--- a/src/software/api/codebase/console.js
+++ b/src/software/api/codebase/console.js
@@ -1,16 +1,7 @@
 var ConsoleManager = (function() {
-    let dataType = {};
-    let currentDataType = '';
     var consolePreviewer = function(data, container) {
             var renderObject = function(key, data, parent, isChildProperty, isInactive) {
                     var type = typeof(data);
-                    if (data.uid) {
-                        currentDataType = dataType[data.uid];
-                        delete dataType[data.uid];
-                        if (type === 'object' && !Array.isArray(data)) {
-                            data = data.data ?? null;
-                        }
-                    }
                     
                     if (type === "object") {
                         if (Array.isArray(data)) {
@@ -27,7 +18,6 @@ var ConsoleManager = (function() {
                     }
                     if (renderers[type]) {
                         renderers[type](key, data, parent, isChildProperty, isInactive);
-                        currentDataType = '';
                     }
                 },
                 createElement = function(tag, className, innerHTML) {
@@ -146,9 +136,6 @@ var ConsoleManager = (function() {
                             keyElement = isChildProperty ? createElement("span", "data-object-key", key + ": ") : null;
                         
                         let arrayLabel = 'Array';
-                        if (currentDataType) {
-                            arrayLabel = currentDataType;
-                        }
                         const value = createElement("span", "data-object-value", `${arrayLabel}[${data.length}]`),
                             preview = !isChildProperty ? createElement("span", "data-object-preview", " [ ... ]") : null,
                             children = createElement("span", "data-object-children-hidden", "");
@@ -192,7 +179,6 @@ var ConsoleManager = (function() {
                 clear = function() {
                     data = null;
                     container = null;
-                    dataType = {};
                 };
 
             renderObject(null, data, container);
@@ -276,17 +262,13 @@ var ConsoleManager = (function() {
                 views = [];
                 container.innerHTML = "";
             };
-        
-        function setDataType(type) {
-            dataType = type;
-        }
+
         return {
             render: render,
             process: process,
             log: consoleLog,
             error: consoleError,
-            clear: clear,
-            setDataType: setDataType
+            clear: clear
         };
     };
 })();

--- a/src/software/api/codebase/iframe.html
+++ b/src/software/api/codebase/iframe.html
@@ -78,7 +78,7 @@
                         call = activeCalls.get(data.uid);
                         if (call) {
                             if (type === "success") {
-                                call.successCallback(data.data, data.uid);
+                                call.successCallback(data.data);
                             } else {
                                 call.errorCallback(data.data);
                             }
@@ -101,8 +101,8 @@
                                 type: "call",
                                 method: method,
                                 params: params
-                            }, function(result, uid) {
-                                (successCallback || console.log)({data: result, uid: uid});
+                            }, function(result) {
+                                (successCallback || console.log)(result);
                                 resolve(result);
                             }, function(error) {
                                 (errorCallback || console.error)(error);

--- a/src/software/api/runner.js
+++ b/src/software/api/runner.js
@@ -12,7 +12,6 @@ let loginFormHasBeenShown = false;
 
 export default function ApiRunnerCore() {
 
-    let callDataType = {};
     const htmlEscape = str => String(str || "")
         .replace(/&/g, "&amp;")
         .replace(/"/g, "&quot;")
@@ -140,16 +139,12 @@ export default function ApiRunnerCore() {
                 });
             });
             postMessages.on("call", data => {
-                if (data.params.typeName) {
-                    callDataType[data.uid.toString()] = data.params.typeName;
-                }
                 api.call(data.method, data.params, getSendResponse("success", data.uid), getSendResponse("error", data.uid));
             });
             postMessages.on("multiCall", data => {
                 api.multiCall(data.calls, getSendResponse("success", data.uid), getSendResponse("error", data.uid));
             });
             postMessages.on("log", data => {
-                callDataType && consoleManager.setDataType(callDataType);
                 consoleManager.log.apply(consoleManager.log, data.data);
             });
             postMessages.on("error", data => {


### PR DESCRIPTION
Displaying entity names in the console when making Get calls has been producing confusing behaviour for the users.
Since there is no simple way to correct the bug, the feature is removed. 