### PR TITLE
INTGR-489: Separate HTML and JS & add deprecation notice

### DIFF
--- a/src/software/js-samples/importDevices.html
+++ b/src/software/js-samples/importDevices.html
@@ -64,14 +64,17 @@
 
             <!-- Description section of the example -->
             <div class="description">
-                <p>This example imports devices to your account using comma-separated values (CSV). The provided input will be parsed, added, and saved to your account. Please note the following rules:
+                <p>
+                    The bulk import devices tool has been deprecated, please use the native myGeotab functionality available through Assets > Add a new asset > Add multiple assets.
+                </p>
+                <!-- <p>This example imports devices to your account using comma-separated values (CSV). The provided input will be parsed, added, and saved to your account. Please note the following rules:
                 <ol>
                     <li class="importDevices-rulesList">The `<b>GroupName</b>` field cannot be an `<b>AssetType</b>`.</li>
                     <li class="importDevices-rulesList">If an `<b>AssetType</b>` value is not provided or not found, it will default to "Vehicle".</li>
                     <li class="importDevices-rulesList">If the `<b>Vin</b>` field is not given, it will be treated as an empty string.</li>
                 </ol>
                 Please ensure your CSV input follows these guidelines to ensure a successful device import.
-                </p>
+                </p> -->
             </div>
 
             <!-- Methods/objects used section containing the links to the specific SDK references used -->
@@ -90,7 +93,7 @@
         </div>
 
         <!-- Components which make up the example are placed here -->
-        <div id="example-content">
+        <!-- <div id="example-content">
             <form>
                 <p>
                     Use the text box below to import multiple devices at a time. Place each device
@@ -112,7 +115,7 @@
                 <span id="result" class="importDevices-result"></span>
             </form>
         </div>
-    </div>
+    </div> -->
 
     <!-- JavaScript file containing the api functionality -->
     <script src="js/api.js"></script>
@@ -120,261 +123,7 @@
     <!-- JavaScript file containing the login functionality (creating the sign-in modal) -->
     <script src="js/login.js"></script>
 
-    <!-- The JavaScript used for the example is present in the same HTML file here -->
-    <script type="text/javascript">
-        document.addEventListener("DOMContentLoaded", async function () {
-            let allGroupCache;
-            let assetTypeCache;
-            let nonAssetTypeCache;
-
-            document.getElementById("importDevices").addEventListener("click", async (event) => {
-                event.preventDefault();
-                // Cache should be updated every time the button is clicked, to ensure that the latest data is retrieved.
-                allGroupCache = await getGroup();
-                assetTypeCache = getGroupDescendants("GroupAssetTypeId");
-                nonAssetTypeCache = allGroupCache.filter(x => !assetTypeCache.some(y => y.id === x.id));
-                await importDevices();
-            });
-
-            async function importDevices() {
-                clearLogs();
-
-                const data = document.getElementById("content").value;
-                const createGroupIfNotExist = document.getElementById("createGroups").checked;
-                
-                if (!isDataValid(data)) {
-                    return;
-                }
-                
-                const dataRows = data.split("\n");
-                
-                for (let i = 0; i < dataRows.length; i++) {
-                    try {
-                        addLogs(`Row ${i+1}:`);
-                        const row = dataRows[i];
-                        if (!isRowValid(row)) {
-                            continue;
-                        }
-                        
-                        const deviceData = row.split(",");
-                        if (!isDeviceDataValid(deviceData)) {
-                            continue;
-                        }
-                        const deviceSerialNumber = deviceData[0]?.trim();
-                        const deviceName = deviceData[1]?.trim();
-                        const deviceGroupName = deviceData[2]?.trim();
-                        const deviceAssetTypeName = deviceData[3]?.trim();
-                        const deviceVin = deviceData[4]?.trim();
-
-                        let groups = await handleNonAssetType(deviceGroupName, createGroupIfNotExist);
-                        let assetTypes = await handleAssetType(deviceAssetTypeName);
-
-                        groups = groups.concat(assetTypes);
-
-                        const device = {
-                            serialNumber: deviceSerialNumber,
-                            name: deviceName,
-                            groups: groups,
-                            vehicleIdentificationNumber: deviceVin,
-                            comment: "Imported with SDK js samples: importDevices",
-                        };
-                        await addDevice(device);
-                        addLogs(`- New Device Added: ${deviceName}`);
-                    } catch (error) {
-                        addLogs(`- ${error}`);
-                        console.error(error);
-                    }
-                }
-                addLogs("Importing finished.");
-            }
-
-            function clearLogs() {
-                const parentElement = document.getElementById("result");
-                while (parentElement.firstChild) {
-                    parentElement.removeChild(parentElement.firstChild);
-                }
-            }
-
-            function addLogs(text) {
-                let log = document.createElement("p");
-                log.innerText = text;
-                document.getElementById("result").appendChild(log);
-            }
-
-            // Returns NonAssetType id. Adds a new group if createGroupIfNotExist (checkbox is checked). 
-            async function handleNonAssetType(deviceGroupName, createGroupIfNotExist) {
-                let groups = [];
-                let groupObject = nonAssetTypeCache.find(x => x.name === deviceGroupName);
-                if (!groupObject) {
-                    // If cannot find AssetType and createGroupIfNotExist is false, throw an error
-                    if (!isNonAssetTypeValid(deviceGroupName, createGroupIfNotExist)) {
-                        return;
-                    }
-                    groupObject = {
-                        name: deviceGroupName,
-                        comments: "Imported with SDK js samples: importDevices",
-                        parent: { id: "GroupCompanyId" }
-                    }
-                    groupObject.id = await AddGroup(groupObject);
-                    groups.push({ id: groupObject.id });
-                    allGroupCache.push(groupObject);
-                    nonAssetTypeCache.push(groupObject);
-                    addLogs(`- New Group Added: ${deviceGroupName}`);
-                    
-                } else {
-                    groups.push({ id: groupObject.id });
-                }
-                return groups;
-            }
-            
-            // Returns AssetType id. Default to 'Vehicle' if the given AssetType is not found
-            function handleAssetType(deviceAssetTypeName) {
-                const assetTypeObject = assetTypeCache.find(x => x.name === deviceAssetTypeName);
-                if (deviceAssetTypeName && assetTypeObject) {
-                    return [{ id: assetTypeObject.id }];
-                } else {
-                    if (!deviceAssetTypeName || deviceAssetTypeName === "") {
-                        addLogs(`- No Asset Type provided. Defaulting to "Vehicle" Asset Type.`);
-                    } else {
-                        addLogs(`- Cannot find Asset Type: "${deviceAssetTypeName}". Defaulting to "Vehicle" Asset Type.`);
-                    }
-                    return [{ id: "GroupVehicleId" }];
-                };
-            }
-
-            function getGroup() {
-                return new Promise((resolve, reject) => {
-                    api.call("Get", {
-                        typeName: "Group",
-                        propertySelector: {
-                            fields: ["id", "name", "children"]
-                        }
-                    }, function (result) {
-                        resolve(result);
-                    }, function (error) {
-                        reject(`Error: Cannot get Group - ${error}`);
-                    });
-                })
-            }
-
-            // Use a single call instead of a multi-call to avoid cascading failures, 
-            // as a single failure in the multi-call could lead to other calls failing as well.
-            function addDevice(entity) {
-                return new Promise((resolve, reject) => {
-                    api.call("Add", {
-                        typeName: "Device",
-                        entity: entity
-                    }, function (result) {
-                        resolve(result);
-                    }, function (error) {
-                        reject(`Error: Cannot add device - ${error}`);
-                    });
-                })
-            }
-
-            function AddGroup(entity) {
-                return new Promise((resolve, reject) => {
-                    api.call("Add", {
-                        typeName: "Group",
-                        entity: entity
-                    }, function (result) {
-                        resolve(result);
-                    }, function (error) {
-                        reject(`Error: Cannot add group - ${error}`);
-                    });
-                })
-            }
-
-
-            function isDataValid(data) {
-                if (data?.trim() === "") {
-                    addLogs("- Error: The provided input is empty or contains only whitespace characters. Expected: SerialNumber,Name,GroupName,AssetType(Optional),VIN(Optional)");
-                    console.error(`Error: The provided input is empty or contains only whitespace characters. Expected: SerialNumber,Name,GroupName,AssetType(Optional),VIN(Optional)`);
-                    addLogs("Importing finished.");
-                    return false;
-                }
-                return true;
-            }
-
-            function isRowValid(row) {
-                if (row?.trim() === "") { // Trim whitespace before checking if row is empty
-                    throw new Error(`No device data. Expected: SerialNumber,Name,GroupName,AssetType(Optional),VIN(Optional)`);
-                }
-                return true;
-            }
-
-            function isDeviceDataValid(deviceData) {
-                if (deviceData.length < 3) {
-                    throw new Error("Insufficient number of properties. Expected: SerialNumber,Name,GroupName,AssetType(Optional),VIN(Optional)");
-                }
-                if (deviceData.length > 5) {
-                    throw new Error("Too many properties. Expected: SerialNumber,Name,GroupName,AssetType(Optional),VIN(Optional)");
-                }
-                if (!deviceData[0] || deviceData[0].trim() === "") {
-                    throw new Error("Serial Number is required.");
-                }
-                if (!deviceData[1] || deviceData[1].trim() === "") {
-                    throw new Error("Device Name is required.");
-                }
-                if (!deviceData[2] || deviceData[2].trim() === "") {
-                    throw new Error("Group Name is required.");
-                }
-                if (deviceData[0].length > 255) {
-                    throw new Error("Serial Number exceeds 255 characters.");
-                }
-                if (deviceData[1].length > 255) {
-                    throw new Error("Device Name exceeds 255 characters.");
-                }
-                if (deviceData[2].length > 255) {
-                    throw new Error("Group Name exceeds 255 characters.");
-                }
-                // assetType is optional
-                if (deviceData[3]?.length > 255) {
-                    throw new Error("Asset Type exceeds 255 characters.");
-                }
-                // vin is optional
-                if (deviceData[4]?.length > 255) {
-                    throw new Error("VIN exceeds 255 characters.");
-                }
-                return true;
-            }
-
-            function isNonAssetTypeValid(deviceGroupName, createGroupIfNotExist) {
-                if (assetTypeCache.find(x => x.name === deviceGroupName) ) { 
-                    throw new Error(`This is a Asset Type: ${deviceGroupName}`);
-                }
-                if (!createGroupIfNotExist) {
-                    throw new Error(`This Group Name does not exist: ${deviceGroupName}`);
-                }
-                return true;
-            }
-
-            // Recursive function to retrieve all descendants of a group.
-            function getGroupDescendants(groupId) {
-                let group = allGroupCache.find(x => x.id === groupId);
-                if (group) {
-                    let list = [group];
-                    if (group.children.length > 0) {
-                        for (let i of group.children) {
-                            let descendants = getGroupDescendants(i.id);
-                            if (descendants !== null) {
-                                list = list.concat(descendants);
-                            }
-                        }
-                    }
-                    return list;
-                }
-                return null;
-            }
-
-            function isAssetType(group) {
-                return assetTypeCache.some(x => x.id === group.id);
-            }
-
-            function isNonAssetType(group) {
-                return nonAssetTypeCache.some(x => x.id === group.id);
-            }
-        });
-    </script>
+    <!-- The JavaScript used for the example -->
+    <!-- <script src="js/importDevices.js"></script> -->
 </body>
 </html>

--- a/src/software/js-samples/js/importDevices.js
+++ b/src/software/js-samples/js/importDevices.js
@@ -1,0 +1,253 @@
+document.addEventListener("DOMContentLoaded", async function () {
+    let allGroupCache;
+    let assetTypeCache;
+    let nonAssetTypeCache;
+
+    document.getElementById("importDevices").addEventListener("click", async (event) => {
+        event.preventDefault();
+        // Cache should be updated every time the button is clicked, to ensure that the latest data is retrieved.
+        allGroupCache = await getGroup();
+        assetTypeCache = getGroupDescendants("GroupAssetTypeId");
+        nonAssetTypeCache = allGroupCache.filter(x => !assetTypeCache.some(y => y.id === x.id));
+        await importDevices();
+    });
+
+    async function importDevices() {
+        clearLogs();
+
+        const data = document.getElementById("content").value;
+        const createGroupIfNotExist = document.getElementById("createGroups").checked;
+        
+        if (!isDataValid(data)) {
+            return;
+        }
+        
+        const dataRows = data.split("\n");
+        
+        for (let i = 0; i < dataRows.length; i++) {
+            try {
+                addLogs(`Row ${i+1}:`);
+                const row = dataRows[i];
+                if (!isRowValid(row)) {
+                    continue;
+                }
+                
+                const deviceData = row.split(",");
+                if (!isDeviceDataValid(deviceData)) {
+                    continue;
+                }
+                const deviceSerialNumber = deviceData[0]?.trim();
+                const deviceName = deviceData[1]?.trim();
+                const deviceGroupName = deviceData[2]?.trim();
+                const deviceAssetTypeName = deviceData[3]?.trim();
+                const deviceVin = deviceData[4]?.trim();
+
+                let groups = await handleNonAssetType(deviceGroupName, createGroupIfNotExist);
+                let assetTypes = await handleAssetType(deviceAssetTypeName);
+
+                groups = groups.concat(assetTypes);
+
+                const device = {
+                    serialNumber: deviceSerialNumber,
+                    name: deviceName,
+                    groups: groups,
+                    vehicleIdentificationNumber: deviceVin,
+                    comment: "Imported with SDK js samples: importDevices",
+                };
+                await addDevice(device);
+                addLogs(`- New Device Added: ${deviceName}`);
+            } catch (error) {
+                addLogs(`- ${error}`);
+                console.error(error);
+            }
+        }
+        addLogs("Importing finished.");
+    }
+
+    function clearLogs() {
+        const parentElement = document.getElementById("result");
+        while (parentElement.firstChild) {
+            parentElement.removeChild(parentElement.firstChild);
+        }
+    }
+
+    function addLogs(text) {
+        let log = document.createElement("p");
+        log.innerText = text;
+        document.getElementById("result").appendChild(log);
+    }
+
+    // Returns NonAssetType id. Adds a new group if createGroupIfNotExist (checkbox is checked). 
+    async function handleNonAssetType(deviceGroupName, createGroupIfNotExist) {
+        let groups = [];
+        let groupObject = nonAssetTypeCache.find(x => x.name === deviceGroupName);
+        if (!groupObject) {
+            // If cannot find AssetType and createGroupIfNotExist is false, throw an error
+            if (!isNonAssetTypeValid(deviceGroupName, createGroupIfNotExist)) {
+                return;
+            }
+            groupObject = {
+                name: deviceGroupName,
+                comments: "Imported with SDK js samples: importDevices",
+                parent: { id: "GroupCompanyId" }
+            }
+            groupObject.id = await AddGroup(groupObject);
+            groups.push({ id: groupObject.id });
+            allGroupCache.push(groupObject);
+            nonAssetTypeCache.push(groupObject);
+            addLogs(`- New Group Added: ${deviceGroupName}`);
+            
+        } else {
+            groups.push({ id: groupObject.id });
+        }
+        return groups;
+    }
+    
+    // Returns AssetType id. Default to 'Vehicle' if the given AssetType is not found
+    function handleAssetType(deviceAssetTypeName) {
+        const assetTypeObject = assetTypeCache.find(x => x.name === deviceAssetTypeName);
+        if (deviceAssetTypeName && assetTypeObject) {
+            return [{ id: assetTypeObject.id }];
+        } else {
+            if (!deviceAssetTypeName || deviceAssetTypeName === "") {
+                addLogs(`- No Asset Type provided. Defaulting to "Vehicle" Asset Type.`);
+            } else {
+                addLogs(`- Cannot find Asset Type: "${deviceAssetTypeName}". Defaulting to "Vehicle" Asset Type.`);
+            }
+            return [{ id: "GroupVehicleId" }];
+        };
+    }
+
+    function getGroup() {
+        return new Promise((resolve, reject) => {
+            api.call("Get", {
+                typeName: "Group",
+                propertySelector: {
+                    fields: ["id", "name", "children"]
+                }
+            }, function (result) {
+                resolve(result);
+            }, function (error) {
+                reject(`Error: Cannot get Group - ${error}`);
+            });
+        })
+    }
+
+    // Use a single call instead of a multi-call to avoid cascading failures, 
+    // as a single failure in the multi-call could lead to other calls failing as well.
+    function addDevice(entity) {
+        return new Promise((resolve, reject) => {
+            api.call("Add", {
+                typeName: "Device",
+                entity: entity
+            }, function (result) {
+                resolve(result);
+            }, function (error) {
+                reject(`Error: Cannot add device - ${error}`);
+            });
+        })
+    }
+
+    function AddGroup(entity) {
+        return new Promise((resolve, reject) => {
+            api.call("Add", {
+                typeName: "Group",
+                entity: entity
+            }, function (result) {
+                resolve(result);
+            }, function (error) {
+                reject(`Error: Cannot add group - ${error}`);
+            });
+        })
+    }
+
+
+    function isDataValid(data) {
+        if (data?.trim() === "") {
+            addLogs("- Error: The provided input is empty or contains only whitespace characters. Expected: SerialNumber,Name,GroupName,AssetType(Optional),VIN(Optional)");
+            console.error(`Error: The provided input is empty or contains only whitespace characters. Expected: SerialNumber,Name,GroupName,AssetType(Optional),VIN(Optional)`);
+            addLogs("Importing finished.");
+            return false;
+        }
+        return true;
+    }
+
+    function isRowValid(row) {
+        if (row?.trim() === "") { // Trim whitespace before checking if row is empty
+            throw new Error(`No device data. Expected: SerialNumber,Name,GroupName,AssetType(Optional),VIN(Optional)`);
+        }
+        return true;
+    }
+
+    function isDeviceDataValid(deviceData) {
+        if (deviceData.length < 3) {
+            throw new Error("Insufficient number of properties. Expected: SerialNumber,Name,GroupName,AssetType(Optional),VIN(Optional)");
+        }
+        if (deviceData.length > 5) {
+            throw new Error("Too many properties. Expected: SerialNumber,Name,GroupName,AssetType(Optional),VIN(Optional)");
+        }
+        if (!deviceData[0] || deviceData[0].trim() === "") {
+            throw new Error("Serial Number is required.");
+        }
+        if (!deviceData[1] || deviceData[1].trim() === "") {
+            throw new Error("Device Name is required.");
+        }
+        if (!deviceData[2] || deviceData[2].trim() === "") {
+            throw new Error("Group Name is required.");
+        }
+        if (deviceData[0].length > 255) {
+            throw new Error("Serial Number exceeds 255 characters.");
+        }
+        if (deviceData[1].length > 255) {
+            throw new Error("Device Name exceeds 255 characters.");
+        }
+        if (deviceData[2].length > 255) {
+            throw new Error("Group Name exceeds 255 characters.");
+        }
+        // assetType is optional
+        if (deviceData[3]?.length > 255) {
+            throw new Error("Asset Type exceeds 255 characters.");
+        }
+        // vin is optional
+        if (deviceData[4]?.length > 255) {
+            throw new Error("VIN exceeds 255 characters.");
+        }
+        return true;
+    }
+
+    function isNonAssetTypeValid(deviceGroupName, createGroupIfNotExist) {
+        if (assetTypeCache.find(x => x.name === deviceGroupName) ) { 
+            throw new Error(`This is a Asset Type: ${deviceGroupName}`);
+        }
+        if (!createGroupIfNotExist) {
+            throw new Error(`This Group Name does not exist: ${deviceGroupName}`);
+        }
+        return true;
+    }
+
+    // Recursive function to retrieve all descendants of a group.
+    function getGroupDescendants(groupId) {
+        let group = allGroupCache.find(x => x.id === groupId);
+        if (group) {
+            let list = [group];
+            if (group.children.length > 0) {
+                for (let i of group.children) {
+                    let descendants = getGroupDescendants(i.id);
+                    if (descendants !== null) {
+                        list = list.concat(descendants);
+                    }
+                }
+            }
+            return list;
+        }
+        return null;
+    }
+
+    function isAssetType(group) {
+        return assetTypeCache.some(x => x.id === group.id);
+    }
+
+    function isNonAssetType(group) {
+        return nonAssetTypeCache.some(x => x.id === group.id);
+    }
+});


### PR DESCRIPTION
https://jira.geotab.com/browse/INTGR-489

We want to encourage people to use the native bulk device import feature of myGeotab over the sample at:  
https://developers.geotab.com/myGeotab/codeSamples/javascriptSamples

Acceptance criteria:

- remove view live demo button
- separate js from html
- replace html with the following notice: The bulk import devices tool has been deprecated, please use the native myGeotab functionality available through Assets > Add a new asset > Add multiple assets
- add js script as a separate file in here: https://github.com/Geotab/sdk/tree/master/src/software/js-samples

Update view source code button to point to .js file